### PR TITLE
Crear archivo de configuración

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1,2 +1,11 @@
 sudo apt install python-configparser
 sudo apt install python-nmap nmap
+
+if test -r config.ini
+then
+echo "Realiza el siguiente paso"
+else
+touch config.ini
+chmod 777 config.ini
+echo "Configura el archivo config.ini según la guía"
+fi


### PR DESCRIPTION
Comprueba si al ejecutar setup.sh existe el archivo de configuración necesario config.ini y en caso de que NO esté creado, lo crea con los permisos necesario para que el usuario tan solo tenga que configurarlo con los parámetros necesarios. (En futuras mejoras intentaré que el archivo de configuración se genere automáticamente poniendo el token como argumento)